### PR TITLE
Added support for registering WAR files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ For example, to host a servlet at `/my-app`:
 
 For more information see the [example servlet app](examples/servlet_app).
 
+#### `add-war-handler`
+
+`add-war-handler` takes two arguments: `[war-path ctxt-path]`.  The `war-path` is the path to
+a WAR file. The `ctxt-path` is the URL prefix at which the WAR will be registered.
+
+For example, to host a WAR at `/cas`:
+
+```clj
+(defservice cas-webservice
+  {:depends [[:webserver-service add-war-handler]
+             [:config-service get-in-config]]
+   :provides []}
+  (let [war-path (get-in-config [:cas :war-path])
+        context-path "/cas"]
+    (add-war-handler war-path context-path))
+  {})
+```
+
 #### `join`
 
 This function is not recommended for normal use, but is provided for compatibility

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [org.eclipse.jetty/jetty-servlet "7.6.1.v20120215"]
                  [org.eclipse.jetty/jetty-server "7.6.1.v20120215"
                   :exclusions [org.eclipse.jetty.orbit/javax.servlet]]
+                 [org.eclipse.jetty/jetty-webapp "7.6.1.v20120215"]
 
                  [ring/ring-servlet "1.1.8"]]
 

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty7_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty7_core.clj
@@ -11,6 +11,7 @@
            (org.eclipse.jetty.server.ssl SslSelectChannelConnector)
            (org.eclipse.jetty.server.nio SelectChannelConnector)
            (org.eclipse.jetty.servlet ServletContextHandler ServletHolder)
+           (org.eclipse.jetty.webapp WebAppContext WebAppContext)
            (javax.servlet.http HttpServletRequest HttpServletResponse)
            (java.util.concurrent Executors)
            (javax.servlet Servlet))
@@ -199,6 +200,15 @@
      (.addHandler (:handlers webserver) handler)
      (.start handler)
      handler)))
+
+(defn add-war-handler
+  [webserver war-path ctxt-path]
+  (let [handler (doto (WebAppContext.)
+                  (.setContextPath ctxt-path)
+                  (.setWar war-path))]
+    (.addHandler (:handlers webserver) handler)
+    (.start handler)
+    handler))
 
 (defn join
   [webserver]

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty7_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty7_service.clj
@@ -9,6 +9,7 @@
 (defprotocol WebserverService
   (add-ring-handler [this handler path])
   (add-servlet-handler [this servlet path] [this servlet path servlet-init-params])
+  (add-war-handler [this war-path ctxt-path])
   (join [this]))
 
 (defservice jetty7-service
@@ -45,6 +46,10 @@
   (add-servlet-handler [this servlet path servlet-init-context]
     (let [s ((service-context this) :jetty7-server)]
      (core/add-servlet-handler s servlet path servlet-init-context)))
+
+  (add-war-handler [this war-path ctxt-path]
+    (let [s ((service-context this) :jetty7-server)]
+      (core/add-war-handler s war-path ctxt-path)))
 
   (join [this]
     (let [s ((service-context this) :jetty7-server)]


### PR DESCRIPTION
`add-war-handler` takes two arguments: `[war-path ctxt-path]`.  The `war-path` is the path to
a WAR file. The `ctxt-path` is the URL prefix at which the WAR will be registered.
