### PR TITLE
(PE-2790) Fix for Jetty always opening binding for a plain http port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.lein-failures
+.lein-repl-history
+target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.3.3-SNAPSHOT
+ * Fix bug where even if no http "port" was specified in the webserver config,
+   the Jetty webserver was still opening an http binding on port 8080.  An
+   http port binding will now be opened only if a "port" is specified in the
+   config file.
+
+

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty7_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty7_config.clj
@@ -66,13 +66,15 @@
 
 (defn configure-web-server
   "Update the supplied config map with information about the HTTP webserver to
-  start. This will specify client auth, and add a default host/port
-  http://localhost:8080 if none are supplied (and SSL is not specified)."
+  start. This will specify client auth."
   [options]
   {:pre  [(map? options)]
    :post [(map? %)
           (missing? % :ssl-key :ssl-cert :ssl-ca-cert)]}
-  (let [defaults          {:max-threads 50 :port 8080}
+  (if (missing? options :port :ssl-port)
+    (throw (IllegalArgumentException.
+             "Either port or ssl-port must be specified on the config in order for a port binding to be opened")))
+  (let [defaults          {:max-threads 50}
         options           (merge defaults options)
         pem-required-keys [:ssl-key :ssl-cert :ssl-ca-cert]
         pem-config        (select-keys options pem-required-keys)]

--- a/test-resources/config/jetty/jetty-plaintext-http.ini
+++ b/test-resources/config/jetty/jetty-plaintext-http.ini
@@ -1,0 +1,2 @@
+[webserver]
+port = 8080

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty7_config_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty7_config_test.clj
@@ -14,17 +14,22 @@
 
 (deftest http-configuration
   (testing "should enable need-client-auth"
-    (let [config (configure-web-server {:client-auth false})]
+    (let [config (configure-web-server {:client-auth false :port 8080})]
       (is (= (get config :client-auth) :need))))
 
   (let [old-config {:keystore       "/some/path"
                     :key-password   "pw"
+                    :port           8080
                     :truststore     "/some/other/path"
                     :trust-password "otherpw"}]
     (testing "should not muck with keystore/truststore settings if PEM-based SSL settings are not provided"
       (let [processed-config (configure-web-server old-config)]
         (is (= old-config
-               (select-keys processed-config [:keystore :key-password :truststore :trust-password])))))
+               (select-keys processed-config [:keystore
+                                              :key-password
+                                              :port
+                                              :truststore
+                                              :trust-password])))))
 
     (testing "should fail if some but not all of the PEM-based SSL settings are found"
       (let [partial-pem-config (merge old-config {:ssl-ca-cert "/some/path"})]
@@ -54,14 +59,20 @@
           (is (not (contains? processed-config :ssl-ca-cert)))))))
 
   (testing "should set max-threads"
-    (let [config (configure-web-server {})]
+    (let [config (configure-web-server {:port 8080})]
       (is (contains? config :max-threads))))
 
   (testing "should merge configuration with initial-configs correctly"
-    (let [user-config {:truststore "foo"}
+    (let [user-config {:port 8080 :truststore "foo"}
           config      (configure-web-server user-config)]
-      (is (= config {:truststore "foo" :max-threads 50 :client-auth :need :port 8080})))
+      (is (= config {:truststore "foo"
+                     :max-threads 50
+                     :client-auth :need
+                     :port 8080})))
     (let [user-config {:max-threads 500 :truststore "foo" :port 8000}
           config      (configure-web-server user-config)]
-      (is (= config {:truststore "foo" :max-threads 500 :client-auth :need :port 8000})))))
+      (is (= config {:truststore "foo"
+                     :max-threads 500
+                     :client-auth :need
+                     :port 8000})))))
 

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty7_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty7_service_test.clj
@@ -1,22 +1,24 @@
 (ns puppetlabs.trapperkeeper.services.webserver.jetty7-service-test
-  (:import  [servlet SimpleServlet])
+  (:import  (java.net ConnectException)
+            [servlet SimpleServlet])
   (:require [clojure.test :refer :all]
             [clj-http.client :as http-client]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
-            [puppetlabs.trapperkeeper.services.webserver.jetty7-service :refer :all]
             [puppetlabs.trapperkeeper.services :refer [stop service-context]]
+            [puppetlabs.trapperkeeper.services.webserver.jetty7-service :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [bootstrap-services-with-empty-config
                                                                   bootstrap-services-with-cli-data]]
             [puppetlabs.kitchensink.testutils.fixtures :refer [with-no-jvm-shutdown-hooks]]))
 
 (use-fixtures :once with-no-jvm-shutdown-hooks)
 
-(deftest jetty-webserver-service
+(deftest jetty-jetty7-service
   (testing "ring support"
-    (let [app              (bootstrap-services-with-cli-data [jetty7-service] {:config "./test-resources/config/jetty/jetty.ini"})
-          s                (get-service app :WebserverService)
-          add-ring-handler (partial add-ring-handler s)
-          shutdown         (partial stop s (service-context s))
+    (let [app              (bootstrap-services-with-cli-data [jetty7-service]
+                             {:config "./test-resources/config/jetty/jetty-ssl-jks.ini"})
+          s                 (get-service app :WebserverService)
+          add-ring-handler  (partial add-ring-handler s)
+          shutdown          (partial stop s (service-context s))
           body             "Hello World"
           path             "/hello_world"
           ring-handler     (fn [req] {:status 200 :body body})]
@@ -29,8 +31,10 @@
         (finally
           (shutdown)))))
 
-  (testing "servlet support"
-    (let [app                 (bootstrap-services-with-empty-config [jetty7-service])
+  (testing "servlet support with plaintext only port binding"
+    (let [app                 (bootstrap-services-with-cli-data [jetty7-service]
+                                {:config
+                                  "./test-resources/config/jetty/jetty-plaintext-http.ini"})
           s                   (get-service app :WebserverService)
           add-servlet-handler (partial add-servlet-handler s)
           shutdown            (partial stop s (service-context s))
@@ -46,7 +50,9 @@
           (shutdown)))))
 
   (testing "servlet support with empty init param"
-    (let [app                 (bootstrap-services-with-empty-config [jetty7-service])
+    (let [app                 (bootstrap-services-with-cli-data [jetty7-service]
+                                {:config
+                                  "./test-resources/config/jetty/jetty-plaintext-http.ini"})
           s                   (get-service app :WebserverService)
           add-servlet-handler (partial add-servlet-handler s)
           shutdown            (partial stop s (service-context s))
@@ -62,7 +68,9 @@
           (shutdown)))))
 
   (testing "servlet support with non-empty init params"
-    (let [app                 (bootstrap-services-with-empty-config [jetty7-service])
+    (let [app                 (bootstrap-services-with-cli-data [jetty7-service]
+                                {:config
+                                  "./test-resources/config/jetty/jetty-plaintext-http.ini"})
           s                   (get-service app :WebserverService)
           add-servlet-handler (partial add-servlet-handler s)
           shutdown            (partial stop s (service-context s))
@@ -82,10 +90,19 @@
         (finally
           (shutdown)))))
 
+  (testing "webserver bootstrap throws IllegalArgumentException when neither
+            port nor ssl-port specified in the config"
+    (is (thrown-with-msg?
+          IllegalArgumentException
+          #"Either port or ssl-port must be specified on the config in order for a port binding to be opened"
+          (bootstrap-services-with-empty-config [jetty7-service]))
+      "Did not encounter expected exception when no port specified in config"))
+
   (testing "SSL initialization is supported for both .jks and .pem implementations"
     (doseq [config ["./test-resources/config/jetty/jetty-ssl-jks.ini"
                     "./test-resources/config/jetty/jetty-ssl-pem.ini"]]
-      (let [app               (bootstrap-services-with-cli-data [jetty7-service] {:config config})
+      (let [app               (bootstrap-services-with-cli-data [jetty7-service]
+                                {:config config})
             s                 (get-service app :WebserverService)
             add-ring-handler  (partial add-ring-handler s)
             shutdown          (partial stop s (service-context s))
@@ -94,11 +111,19 @@
             ring-handler      (fn [req] {:status 200 :body body})]
         (try
           (add-ring-handler ring-handler path)
-          ;; NOTE that we're not entirely testing SSL here since we're not hitting https 8081
-          ;; but this at least tests the initialization. Unfortunately when you are using a
-          ;; self-signed certificate on the server it's really hard to do a client request
-          ;; against it without getting an SSL error.
-          (let [response (http-client/get (format "http://localhost:8080/%s/" path))]
+          (let [response (http-client/get
+                           (format "https://localhost:8081/%s/" path)
+                           {:keystore         "./test-resources/config/jetty/ssl/keystore.jks"
+                            :keystore-type    "JKS"
+                            :keystore-pass    "Kq8lG9LkISky9cDIYysiadxRx"
+                            :trust-store      "./test-resources/config/jetty/ssl/truststore.jks"
+                            :trust-store-type "JKS"
+                            :trust-store-pass "Kq8lG9LkISky9cDIYysiadxRx"
+                            ; The server's cert in this case uses a CN of
+                            ; "localhost-puppetdb" whereas the URL being reached
+                            ; is "localhost".  The insecure? value of true
+                            ; directs the client to ignore the mismatch.
+                            :insecure?        true})]
             (is (= (:status response) 200))
             (is (= (:body response) body)))
           (finally


### PR DESCRIPTION
Prior to this commit, Jetty would always open a binding for an http
port, whether or not a "port" value was actually specified in the
webserver config for the service.

With the changes in this commit, an http port binding is only
created if one is specified in the webserver config.
